### PR TITLE
Websocket duplicate listeners

### DIFF
--- a/client/services/websocket.js
+++ b/client/services/websocket.js
@@ -13,12 +13,16 @@ module.exports = ['$window', 'Session',
     .on('subscribe', function(channelName) {
       if (Window.websocketLogs) {
         console.log('Websocket subscribed to', channelName);
+        console.log(socket.watchers(channelName));
       }
     })
     .on('unsubscribe', function(channelName) {
       if (Window.websocketLogs) {
         console.log('Websocket unsubscribed from', channelName);
+        console.log(socket.watchers(channelName));
       }
+      // disconnect all watchers from the channel
+      socket.unwatch(channelName);
     })
     .on('error', function(err) {
       console.log('Websocket error:', err);

--- a/client/services/websocket.js
+++ b/client/services/websocket.js
@@ -12,14 +12,12 @@ module.exports = ['$window', 'Session',
     })
     .on('subscribe', function(channelName) {
       if (Window.websocketLogs) {
-        console.log('Websocket subscribed to', channelName);
-        console.log(socket.watchers(channelName));
+        console.log('Websocket subscribed to', channelName, socket.watchers(channelName));
       }
     })
     .on('unsubscribe', function(channelName) {
       if (Window.websocketLogs) {
-        console.log('Websocket unsubscribed from', channelName);
-        console.log(socket.watchers(channelName));
+        console.log('Websocket unsubscribed from', channelName, socket.watchers(channelName));
       }
       // disconnect all watchers from the channel
       socket.unwatch(channelName);


### PR DESCRIPTION
resolves #8 by calling `unwatch()` for all channels on unwatch event

this unbinds all listening functions from the channel so that they are not duplicated when the client reconnects to websocket-server
